### PR TITLE
Fix flaky integration tests caused by ports mismatching between IPv4 and IPv6

### DIFF
--- a/service.go
+++ b/service.go
@@ -195,7 +195,8 @@ func (s *ConcreteService) Endpoint(port int) string {
 		return ""
 	}
 
-	// Do not use "localhost" cause it doesn't work with the AWS DynamoDB client.
+	// Use an IPv4 address instead of "localhost" hostname because our port mapping assumes IPv4
+	// (a port published by a Docker container could be different between IPv4 and IPv6).
 	return fmt.Sprintf("127.0.0.1:%d", localPort)
 }
 
@@ -561,7 +562,9 @@ func (s *HTTPService) Metrics() (_ string, err error) {
 	localPort := s.networkPortsContainerToLocal[s.httpPort]
 
 	// Fetch metrics.
-	res, err := DoGet(fmt.Sprintf("http://localhost:%d/metrics", localPort))
+	// Use an IPv4 address instead of "localhost" hostname because our port mapping assumes IPv4
+	// (a port published by a Docker container could be different between IPv4 and IPv6).
+	res, err := DoGet(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We're experiencing flaky integration tests in Mimir repository, caused by the test being unable to find a specific metric exposed by `/metrics`. For example, a typical error we get is:

```
2022-05-19T10:08:41.1477379Z     querier_test.go:736:
2022-05-19T10:08:41.1477665Z         	Error Trace:	querier_test.go:736
2022-05-19T10:08:41.1477925Z         	Error:      	Received unexpected error:
2022-05-19T10:08:41.1478250Z         	            	metric not found
```

After a long investigation and try and error, I've the feeling I've found the root cause. When running tests in CI, the container port is both exposed on IPv4 and IPv6 address. Most of the times they match (e.g. same port number for both protocols) but sometimes they don't. An example is the following (I've added debug logs):

```
$ docker port e2e-mimir-test-distributor 8080
0.0.0.0:49268
:::49267

$ docker port e2e-mimir-test-ingester 8080
0.0.0.0:49269
:::49268
```

As you can see, distributor port was published on host's 49268 for IPv4. However, the host port 49268 for IPv6 is mapping the ingester!

Our code looks for IPv4 mapping ([see here](https://github.com/grafana/e2e/blob/f226e0b44ae37d348a2a322bf67ea4d97eef53ff/service.go#L708-L710)). When we fetch metrics, we're resolving `hostname`. Instead, we should ensure we connect to the IPv4 port, that's what I'm doing in this PR.