### PR TITLE
increase service backoff retry max values

### DIFF
--- a/service.go
+++ b/service.go
@@ -69,7 +69,7 @@ func NewConcreteService(
 		readiness:                    readiness,
 		retryBackoff: backoff.New(context.Background(), backoff.Config{
 			MinBackoff: 300 * time.Millisecond,
-			MaxBackoff: time.Second,
+			MaxBackoff: 600 * time.Millisecond,
 			MaxRetries: 100, // Sometimes the CI is slow ¯\_(ツ)_/¯
 		}),
 	}

--- a/service.go
+++ b/service.go
@@ -69,8 +69,8 @@ func NewConcreteService(
 		readiness:                    readiness,
 		retryBackoff: backoff.New(context.Background(), backoff.Config{
 			MinBackoff: 300 * time.Millisecond,
-			MaxBackoff: 600 * time.Millisecond,
-			MaxRetries: 50, // Sometimes the CI is slow ¯\_(ツ)_/¯
+			MaxBackoff: time.Second,
+			MaxRetries: 100, // Sometimes the CI is slow ¯\_(ツ)_/¯
 		}),
 	}
 }


### PR DESCRIPTION
One of our CI tests is flaky as sometimes takes longer than usual to start a dependency service.

This PR increases default backoff retry config max values in order to alleviate this situation. 