### PR TITLE
Allow different timeouts when using HTTPService.Metrics()

### DIFF
--- a/service.go
+++ b/service.go
@@ -550,7 +550,8 @@ func (w *LinePrefixLogger) Write(p []byte) (n int, err error) {
 type HTTPService struct {
 	*ConcreteService
 
-	httpPort int
+	metricsTimeout time.Duration
+	httpPort       int
 }
 
 func NewHTTPService(
@@ -563,8 +564,13 @@ func NewHTTPService(
 ) *HTTPService {
 	return &HTTPService{
 		ConcreteService: NewConcreteService(name, image, command, readiness, append(otherPorts, httpPort)...),
+		metricsTimeout:  time.Second,
 		httpPort:        httpPort,
 	}
+}
+
+func (s *HTTPService) SetMetricsTimeout(timeout time.Duration) {
+	s.metricsTimeout = timeout
 }
 
 func (s *HTTPService) Metrics() (_ string, err error) {
@@ -574,7 +580,7 @@ func (s *HTTPService) Metrics() (_ string, err error) {
 	// Fetch metrics.
 	// Use an IPv4 address instead of "localhost" hostname because our port mapping assumes IPv4
 	// (a port published by a Docker container could be different between IPv4 and IPv6).
-	res, err := DoGet(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort))
+	res, err := DoGetWithTimeout(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort), s.metricsTimeout)
 	if err != nil {
 		return "", err
 	}

--- a/util.go
+++ b/util.go
@@ -74,31 +74,37 @@ func BuildArgs(flags map[string]string) []string {
 	return args
 }
 
-// DoGet performs a HTTP GET request towards the supplied URL and using a
+// DoGet performs an HTTP GET request towards the supplied URL and using a
 // timeout of 1 second.
 func DoGet(url string) (*http.Response, error) {
-	return doRequest("GET", url, nil, nil)
+	return doRequestWithTimeout("GET", url, nil, nil, time.Second)
+}
+
+// DoGetWithTimeout performs an HTTP GET request towards the supplied URL and using a
+// specified timeout.
+func DoGetWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+	return doRequestWithTimeout("GET", url, nil, nil, timeout)
 }
 
 // DoGetTLS is like DoGet but allows to configure a TLS config.
 func DoGetTLS(url string, tlsConfig *tls.Config) (*http.Response, error) {
-	return doRequest("GET", url, nil, tlsConfig)
+	return doRequestWithTimeout("GET", url, nil, tlsConfig, time.Second)
 }
 
 // DoPost performs a HTTP POST request towards the supplied URL with an empty
 // body and using a timeout of 1 second.
 func DoPost(url string) (*http.Response, error) {
-	return doRequest("POST", url, strings.NewReader(""), nil)
+	return doRequestWithTimeout("POST", url, strings.NewReader(""), nil, time.Second)
 }
 
-func doRequest(method, url string, body io.Reader, tlsConfig *tls.Config) (*http.Response, error) {
+func doRequestWithTimeout(method, url string, body io.Reader, tlsConfig *tls.Config, timeout time.Duration) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}
 
 	client := &http.Client{
-		Timeout: time.Second,
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},


### PR DESCRIPTION
Default timeout of 1s can be too short, eg. when running race-enabled binary.