### PR TITLE
update kafka image to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,33 +9,33 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
       - name: Go test
         run: make test
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
       - name: Lint
         run: make lint
 
   # integration is run as a GitHub Action, as to run those tests we require a
   # docker socket to be available so containers can be run.
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
       - name: Install Docker Client
         run: |
           sudo bash <<"EOF"

--- a/images/images.go
+++ b/images/images.go
@@ -12,5 +12,5 @@ var (
 	BigtableEmulator = "shopify/bigtable-emulator:0.1.0"
 	Cassandra        = "rinscy/cassandra:3.11.0"
 	SwiftEmulator    = "bouncestorage/swift-aio:55ba4331"
-	Kafka            = "confluentinc/cp-kafka:7.5.3"
+	Kafka            = "apache/kafka:4.0.0"
 )


### PR DESCRIPTION
Updates the used Kafka image to use the latest Kafka version.

Switching from the `confluentinc/cp-kafka` image to the `apache/kafka` one because `4.0.0` hasn't been released yet in `confluentinc/cp-kafka`.

I had to update the Ubuntu version used by the CI because 20.04 has been deprecated and is not available anymore.