### PR TITLE
Migrate tsdb multi-errors to errors package

### DIFF
--- a/scenario.go
+++ b/scenario.go
@@ -1,13 +1,11 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
-
-	"github.com/pkg/errors"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
 const (
@@ -59,7 +57,7 @@ func NewScenario(networkName string) (*Scenario, error) {
 	if out, err := RunCommandAndGetOutput("docker", args...); err != nil {
 		logger.Log(string(out))
 		s.clean()
-		return nil, errors.Wrapf(err, "create docker network '%s'", networkName)
+		return nil, fmt.Errorf("create docker network '%s': %w", networkName, err)
 	}
 
 	return s, nil
@@ -97,7 +95,7 @@ func (s *Scenario) Start(services ...Service) error {
 		startedMx = sync.Mutex{}
 		started   = make([]Service, 0, len(services))
 		errsMx    = sync.Mutex{}
-		errs      = tsdb_errors.NewMulti()
+		errs      []error
 	)
 
 	// Ensure provided services don't conflict with existing ones.
@@ -117,7 +115,7 @@ func (s *Scenario) Start(services ...Service) error {
 			// Start the service.
 			if err := service.Start(s.networkName, s.SharedDir()); err != nil {
 				errsMx.Lock()
-				errs.Add(err)
+				errs = append(errs, err)
 				errsMx.Unlock()
 				return
 			}
@@ -136,7 +134,7 @@ func (s *Scenario) Start(services ...Service) error {
 	// Add the successfully started services to the scenario.
 	s.services = append(s.services, started...)
 
-	return errs.Err()
+	return errors.Join(errs...)
 }
 
 func (s *Scenario) Stop(services ...Service) error {


### PR DESCRIPTION
Upstream Prometheus removed the tsdb errors package in https://github.com/prometheus/prometheus/pull/17768 so we need to remove our dependency on it (so Mimir can import e2e and the updated Prometheus).