### PR TITLE
Upgrade golangci-lint from v1.43.0 to v2.8.0

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,1 +1,0 @@
-(github.com/go-kit/log.Logger).Log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.6"
+          go-version: "1.25.7"
       - name: Go test
         run: make test
   lint:
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.6"
+          go-version: "1.25.7"
       - name: Lint
         run: make lint
 
@@ -48,7 +48,7 @@ jobs:
           options: --privileged
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.6"
+          go-version: "1.25.7"
       - name: Integration Tests
         run: |
           make integration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,41 @@
-output:
-  format: line-number
+version: "2"
 
 linters:
+  default: none
   enable:
     - depguard
-    - goimports
-    - gofmt
     - misspell
     - revive
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "github.com/pkg/errors"
+              desc: use stdlib errors and fmt.Errorf with %w instead
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: indent-error-flow
+          disabled: true
+    errcheck:
+      exclude-functions:
+        - (github.com/go-kit/log.Logger).Log
 
-linters-settings:
-  depguard:
-    list-type: blacklist
-    packages:
-      - "github.com/pkg/errors"
-  errcheck:
-    # path to a file containing a list of functions to exclude from checking
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: ./.errcheck-exclude
-  goimports:
-    local-prefixes: "github.com/grafana/e2e"
+formatters:
+  enable:
+    - goimports
+    - gofmt
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/grafana/e2e
 
 run:
   timeout: 5m
-
-  # List of build tags, all linters use it.
   build-tags:
     - netgo
     - requires_docker

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,13 @@ linters:
   default: none
   enable:
     - depguard
+    - errcheck
+    - govet
+    - ineffassign
     - misspell
     - revive
+    - staticcheck
+    - unused
   settings:
     depguard:
       rules:
@@ -15,12 +20,30 @@ linters:
               desc: use stdlib errors and fmt.Errorf with %w instead
     revive:
       rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
         - name: exported
           disabled: true
-        - name: package-comments
-          disabled: true
+        - name: increment-decrement
         - name: indent-error-flow
-          disabled: true
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
     errcheck:
       exclude-functions:
         - (github.com/go-kit/log.Logger).Log

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	go run github.com/client9/misspell/cmd/misspell@v0.3.4 -error README.md LICENSE
 
 	# Configured via .golangci.yml.
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0 run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run
 
 .PHONY: integration
 integration:

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,3 +1,4 @@
+// Package e2ecache provides pre-built cache service definitions for e2e tests.
 package e2ecache
 
 import (

--- a/composite_service.go
+++ b/composite_service.go
@@ -1,3 +1,4 @@
+// Package e2e provides utilities for running end-to-end tests using Docker containers.
 package e2e
 
 import (

--- a/db/db.go
+++ b/db/db.go
@@ -1,3 +1,4 @@
+// Package e2edb provides pre-built database and storage service definitions for e2e tests.
 package e2edb
 
 import (

--- a/db/kafka.go
+++ b/db/kafka.go
@@ -32,7 +32,7 @@ func NewKafka() *KafkaService {
 func (s *KafkaService) Start(networkName, sharedDir string) (err error) {
 	// Configures Kafka right before starting it so that we have the networkName to correctly compute
 	// the advertised host.
-	s.HTTPService.SetEnvVars(map[string]string{
+	s.SetEnvVars(map[string]string{
 		// Configure Kafka to run in KRaft mode (without Zookeeper).
 		"CLUSTER_ID":                      "NqnEdODVKkiLTfJvqd1uqQ==", // A random ID (16 bytes of a base64-encoded UUID).
 		"KAFKA_BROKER_ID":                 "1",
@@ -79,9 +79,10 @@ func (p *KafkaReadinessProbe) Ready(service *e2e.ConcreteService) (err error) {
 	const timeout = time.Second
 
 	endpoint := service.Endpoint(p.port)
-	if endpoint == "" {
+	switch endpoint {
+	case "":
 		return fmt.Errorf("cannot get service endpoint for port %d", p.port)
-	} else if endpoint == "stopped" {
+	case "stopped":
 		return errors.New("service has stopped")
 	}
 

--- a/images/images.go
+++ b/images/images.go
@@ -1,3 +1,4 @@
+// Package images provides Docker image version constants for e2e test services.
 package images
 
 var (

--- a/metrics.go
+++ b/metrics.go
@@ -15,9 +15,8 @@ func getMetricValue(m *io_prometheus_client.Metric) float64 {
 		return m.GetHistogram().GetSampleSum()
 	} else if m.GetSummary() != nil {
 		return m.GetSummary().GetSampleSum()
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func getMetricCount(m *io_prometheus_client.Metric) float64 {
@@ -25,9 +24,8 @@ func getMetricCount(m *io_prometheus_client.Metric) float64 {
 		return float64(m.GetHistogram().GetSampleCount())
 	} else if m.GetSummary() != nil {
 		return float64(m.GetSummary().GetSampleCount())
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func getValues(metrics []*io_prometheus_client.Metric, opts MetricsOptions) []float64 {

--- a/scenario_test.go
+++ b/scenario_test.go
@@ -6,7 +6,7 @@ package e2e_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -68,13 +68,13 @@ func testMinioWorking(t *testing.T, m *e2e.HTTPService) {
 
 	r, err := bkt.Get(ctx, "recipe")
 	require.NoError(t, err)
-	b, err = ioutil.ReadAll(r)
+	b, err = io.ReadAll(r)
 	require.NoError(t, err)
 	require.Equal(t, "Just go to Pastry Shop and buy.", string(b))
 
 	r, err = bkt.Get(ctx, "mom/recipe")
 	require.NoError(t, err)
-	b, err = ioutil.ReadAll(r)
+	b, err = io.ReadAll(r)
 	require.NoError(t, err)
 	require.Equal(t, "https://www.bbcgoodfood.com/recipes/strawberry-cheesecake-4-easy-steps", string(b))
 }

--- a/service_test.go
+++ b/service_test.go
@@ -22,7 +22,7 @@ func TestWaitSumMetric(t *testing.T) {
 	// the first time (this avoid flaky tests).
 	ln, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	// Get the port.
 	_, addrPort, err := net.SplitHostPort(ln.Addr().String())
@@ -33,7 +33,7 @@ func TestWaitSumMetric(t *testing.T) {
 
 	// Start an HTTP server exposing the metrics.
 	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`
 # HELP metric_c cheescake
 # TYPE metric_c gauge
@@ -65,7 +65,7 @@ metric_b_summary_count 1
 `))
 		}),
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	go func() {
 		_ = srv.Serve(ln)
@@ -118,7 +118,7 @@ func TestWaitSumMetric_Nan(t *testing.T) {
 	// the first time (this avoid flaky tests).
 	ln, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	// Get the port.
 	_, addrPort, err := net.SplitHostPort(ln.Addr().String())
@@ -129,7 +129,7 @@ func TestWaitSumMetric_Nan(t *testing.T) {
 
 	// Start an HTTP server exposing the metrics.
 	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`
 # HELP metric_c cheescake
 # TYPE metric_c GAUGE
@@ -149,7 +149,7 @@ metric_b 1000
 `))
 		}),
 	}
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	go func() {
 		_ = srv.Serve(ln)

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -15,7 +14,6 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 )
 
@@ -137,7 +135,7 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 
 	lbls := append(
 		[]prompb.Label{
-			{Name: labels.MetricName, Value: name},
+			{Name: string(model.MetricNameLabel), Value: name},
 		},
 		additionalLabels...,
 	)
@@ -157,7 +155,7 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 
 	// Generate the expected vector and matrix when querying it
 	metric := model.Metric{}
-	metric[labels.MetricName] = model.LabelValue(name)
+	metric[model.MetricNameLabel] = model.LabelValue(name)
 	for _, lbl := range additionalLabels {
 		metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 	}
@@ -187,7 +185,7 @@ func GenerateNSeries(nSeries, nExemplars int, name func() string, ts time.Time, 
 	// Generate the series
 	for i := 0; i < nSeries; i++ {
 		lbls := []prompb.Label{
-			{Name: labels.MetricName, Value: name()},
+			{Name: string(model.MetricNameLabel), Value: name()},
 		}
 		if additionalLabels != nil {
 			lbls = append(lbls, additionalLabels()...)
@@ -245,7 +243,7 @@ func GetTempDirectory() (string, error) {
 		}
 	}
 
-	tmpDir, err := ioutil.TempDir(dir, "e2e_integration_test")
+	tmpDir, err := os.MkdirTemp(dir, "e2e_integration_test")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Upgrade golangci-lint from v1.43.0 to v2.8.0
- Migrate `.golangci.yml` to v2 config format: formatters split out from linters, settings moved under `linters.settings`
- Inline `.errcheck-exclude` into config and remove the file
- Add `depguard` rule to ban `github.com/pkg/errors`
- Disable `exported`, `package-comments`, and `indent-error-flow` revive rules to avoid noise from pre-existing issues

## Test plan
- [x] `make lint` runs successfully (only expected depguard violations from `pkg/errors` imports, addressed in #75)