### PR TITLE
kafka: Fix permissions for TLS cert generation

### DIFF
--- a/db/kafka.go
+++ b/db/kafka.go
@@ -336,6 +336,7 @@ func (s *KafkaService) generateTLSCerts(networkName, sharedDir string) error {
 	}
 
 	brokerHostname := fmt.Sprintf("%s-kafka", networkName)
+	serverKeyPath := filepath.Join(tlsDir, "server.key")
 	if err := ca.WriteCertificate(
 		&x509.Certificate{
 			Subject:     pkix.Name{CommonName: "kafka"},
@@ -343,9 +344,14 @@ func (s *KafkaService) generateTLSCerts(networkName, sharedDir string) error {
 			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
 		filepath.Join(tlsDir, "server.crt"),
-		filepath.Join(tlsDir, "server.key"),
+		serverKeyPath,
 	); err != nil {
 		return fmt.Errorf("writing server certificate: %w", err)
+	}
+
+	// Make the key readable by the Docker container.
+	if err := os.Chmod(serverKeyPath, 0644); err != nil {
+		return fmt.Errorf("chmod server key: %w", err)
 	}
 
 	return nil
@@ -392,7 +398,9 @@ keytool -importcert \
 
 printf '%%s' "$STORE_PASS" > "$SECRETS_DIR/keystore_creds"
 printf '%%s' "$STORE_PASS" > "$SECRETS_DIR/key_creds"
-printf '%%s' "$STORE_PASS" > "$SECRETS_DIR/truststore_creds"`,
+printf '%%s' "$STORE_PASS" > "$SECRETS_DIR/truststore_creds"
+
+chmod -R a+r "$SECRETS_DIR"`,
 		kafkaSSLStorePassword,
 		e2e.ContainerSharedDir, kafkaTLSDir,
 		e2e.ContainerSharedDir, kafkaTLSSecretsDir,
@@ -400,6 +408,7 @@ printf '%%s' "$STORE_PASS" > "$SECRETS_DIR/truststore_creds"`,
 
 	output, err := e2e.RunCommandAndGetOutput(
 		"docker", "run", "--rm",
+		"--user", "0:0",
 		"-v", fmt.Sprintf("%s:%s:z", sharedDir, e2e.ContainerSharedDir),
 		images.Kafka,
 		"/bin/bash", "-c", script,


### PR DESCRIPTION
The current setup work locally on macOS but [not in CI](https://github.com/grafana/mimir/actions/runs/22711505976/job/65851624760):

```
      kafka_auth_test.go:163: 
          	Error Trace:	/home/runner/work/mimir/mimir/integration/kafka_auth_test.go:163
          	Error:      	Received unexpected error:
          	            	converting PEM to JKS via docker: exit status 1
          	            	output: Could not open file or uri for loading private key from -inkey file from /shared/kafka-tls/server.key
          	            	28EB0D2CBA7F0000:error:8000000D:system library:BIO_new_file:Permission denied:crypto/bio/bss_file.c:67:calling fopen(/shared/kafka-tls/server.key, rb)
          	            	28EB0D2CBA7F0000:error:10080002:BIO routines:BIO_new_file:system lib:crypto/bio/bss_file.c:77:
          	Test:       	TestIngestStorageKafkaAuth/mTLS
```

With this change, files are created as root, then made accessible for all users.

[Tested downstream](https://github.com/grafana/mimir/actions/runs/22862856925/job/66323986361):

```
2026-03-09T16:48:12.4079088Z     --- PASS: TestIngestStorageKafkaAuth/mTLS (9.75s)
```